### PR TITLE
Patch for PHPUnit 5.1.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
     },
 
     "require": {
-        "php": ">= 5.6",
-        "phpunit/phpunit": ">=3.3.3 <6.0.0",
+        "php": "^5.6 || ^7.0",
+        "phpunit/phpunit": "^3.3.3 || ^4.0 || ^5.0",
         "hamcrest/hamcrest-php": "^1.2"
     },
 
     "require-dev": {
-        "mockery/mockery": "^0.9.4"
+        "mockery/mockery": "dev-master#9c29a2"
     }
 }

--- a/src/TestListener.php
+++ b/src/TestListener.php
@@ -50,6 +50,10 @@ class TestListener implements \PHPUnit_Framework_TestListener
     {
     }
 
+    public function addWarning(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_Warning $e, $time)
+    {
+    }
+
     public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
     {
     }


### PR DESCRIPTION
Version 5.1.0 of PHPUnit introduced a new method, `addWarning` to the `PHPUnit_Framework_TestListener` interface.
