### PR TITLE
PHPUnit 6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,11 @@ language: php
 sudo: false
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
-  - hhvm
 
 matrix:
   include:
-    - php: 5.5
+    - php: 7.0
       env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
 install:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A PHPUnit test listener for the hamcrest assertion library.
 
 ## Installation
 
+NOTE:
+
+For PHPUnit >= 6, please use version >= 3.0
+
+For PHPUnit < 6, please use version < 3.0
+
 ```bash
 ~$ composer require --dev graze/hamcrest-test-listener
 ```
@@ -13,7 +19,9 @@ A PHPUnit test listener for the hamcrest assertion library.
  In your **phpunit.xml** file, add the following:
 
 ```xml
-<phpunit>
+<phpunit
+    beStrictAboutTestsThatDoNotTestAnything="false"> <!-- PHPUnit will not consider Hamcrest assertions -->
+    
     <listeners>
         <listener class="\Hamcrest\Adapter\PHPUnit\TestListener"></listener>
     </listeners>

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     },
 
     "require": {
-        "php": "^5.5 || ^7.0",
-        "phpunit/phpunit": "^3.3.3 || ^4.0 || ^5.0",
+        "php": "^7.0",
+        "phpunit/phpunit": "^6.0",
         "hamcrest/hamcrest-php": "^2.0"
     },
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,9 +27,6 @@
     </logging>
 
     <listeners>
-
-        <listener class="\Mockery\Adapter\Phpunit\TestListener"></listener>
-
         <!-- A basic integration test. -->
         <listener class="\Hamcrest\Adapter\PHPUnit\TestListener"></listener>
 

--- a/src/TestListener.php
+++ b/src/TestListener.php
@@ -15,65 +15,26 @@
 namespace Hamcrest\Adapter\PHPUnit;
 
 use Hamcrest\MatcherAssert;
+use PHPUnit\Framework\BaseTestListener;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
 
-class TestListener implements \PHPUnit_Framework_TestListener
+class TestListener extends BaseTestListener
 {
-    /**
-     * @param PHPUnit_Framework_Test $test
-     */
-    public function startTest(\PHPUnit_Framework_Test $test)
+    public function startTest(Test $test)
     {
         MatcherAssert::resetCount();
     }
 
-    /**
-     * @param PHPUnit_Framework_Test $test
-     * @param float $time
-     */
-    public function endTest(\PHPUnit_Framework_Test $test, $time)
+    public function endTest(Test $test, $time)
     {
         try {
-            if ($test instanceof \PHPUnit_Framework_TestCase) {
+            if ($test instanceof TestCase) {
                 $test->addToAssertionCount(MatcherAssert::getCount());
             }
         } catch (\Exception $e) {
             $result = $test->getTestResultObject();
             $result->addError($test, $e, $time);
         }
-    }
-
-    public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
-    {
-    }
-
-    public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time)
-    {
-    }
-
-    /**
-     * @see https://github.com/sebastianbergmann/phpunit/commit/073c4de6d013353df368ccb25f9de37f13f61d2d
-     */
-    // public function addWarning(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_Warning $e, $time)
-    // {
-    // }
-
-    public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
-    {
-    }
-
-    public function addIncompleteTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
-    {
-    }
-
-    public function addSkippedTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
-    {
-    }
-
-    public function addRiskyTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
-    {
-    }
-
-    public function endTestSuite(\PHPUnit_Framework_TestSuite $suite)
-    {
     }
 }

--- a/tests/unit/TestListenerTest.php
+++ b/tests/unit/TestListenerTest.php
@@ -15,15 +15,24 @@
 use Hamcrest\Adapter\PHPUnit\TestListener;
 use Hamcrest\MatcherAssert;
 use Hamcrest\Util;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Test;
 
-class TestListenerTest extends \PHPUnit_Framework_TestCase
+use \Mockery as m;
+
+class TestListenerTest extends TestCase
 {
+    use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
     public static function setUpBeforeClass()
     {
         // Require the Hamcrest global functions.
         Util::registerGlobalFunctions();
     }
 
+    /**
+     * @covers Hamcrest\Adapter\PHPUnit\TestListener::startTest()
+     */
     public function testShouldResetAssertionCountOnTestStart()
     {
         $listener = new TestListener();
@@ -33,16 +42,19 @@ class TestListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(1, MatcherAssert::getCount(), 'Hamcrest is not counting assertions correctly.');
 
-        $listener->startTest(Mockery::mock(PHPUnit_Framework_Test::class));
+        $listener->startTest(m::mock(Test::class));
 
         $this->assertSame(0, MatcherAssert::getCount(), 'The listener did not reset the hamcrest assertion count.');
     }
 
+    /**
+     * @covers Hamcrest\Adapter\PHPUnit\TestListener::endTest()
+     */
     public function testShouldCallAddToAssertionCountOnTestEnd()
     {
         $listener = new TestListener();
 
-        $test = Mockery::mock(PHPUnit_Framework_TestCase::class);
+        $test = m::mock(TestCase::class);
         $test->shouldReceive('addToAssertionCount')->with(1)->once();
 
         // Bump the hamcrest assertion count by 1.
@@ -51,11 +63,14 @@ class TestListenerTest extends \PHPUnit_Framework_TestCase
         $listener->endTest($test, 0.0);
     }
 
+    /**
+     * @covers Hamcrest\Adapter\PHPUnit\TestListener::endTest()
+     */
     public function testShouldOnlyCallAddToAssertionCountOnTestCases()
     {
         $listener = new TestListener();
 
-        $test = Mockery::mock(PHPUnit_Framework_Test::class);
+        $test = m::mock(Test::class);
         $test->shouldReceive('addToAssertionCount')->never();
 
         // Bump the hamcrest assertion count by 1.


### PR DESCRIPTION
This addresses #9 with PHPUnit 6 compatibility. As mentioned in the issue, this is a breaking change as the underlying framework classes now use namespaces. 